### PR TITLE
Fix refresh token auth bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ import { Link, useLoaderData, json, Form } from '@remix-run/react';
 import { getSignInUrl, getSignUpUrl, withAuth, signOut } from '@workos-inc/authkit-remix';
 
 export async function loader({request}: LoaderFunctionArgs) {
-  // additional properties include: sessionId, organizationId, role, impersonator, accessToken
-  const {user} = await withAuth(request);
+  // Additional properties include: sessionId, organizationId, role, impersonator, accessToken, permissions
+  const { user, headers } = await withAuth(request);
 
   return json({
     signInUrl: await getSignInUrl(),
     signUpUrl: await getSignUpUrl(),
     user,
+  }, {
+    // This is important as in the case of authenticating via the refresh token we need to update the session cookie
+    headers,
   });
 }
 
@@ -138,7 +141,7 @@ import type { LoaderFunctionArgs, json } from '@remix-run/node';
 import { withAuth } from '@workos-inc/authkit-remix';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { accessToken } = await withAuth(request);
+  const { accessToken, headers } = await withAuth(request);
 
   if (!accesstoken) {
     // Not signed in
@@ -150,9 +153,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     },
   });
 
-  return json({
-    data: serviceData,
-  });
+  return json(
+    {
+      data: serviceData,
+    },
+    {
+      headers,
+    },
+  );
 }
 ```
 
@@ -164,14 +172,19 @@ To enable debug logs, pass in the debug flag when using `withAuth`.
 import { withAuth, getSignInUrl, getSignUpUrl } from '@workos-inc/authkit-remix';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { user } = await withAuth(request, {
+  const { user, headers } = await withAuth(request, {
     debug: true,
   });
 
-  return json({
-    signInUrl: await getSignInUrl(),
-    signUpUrl: await getSignUpUrl(),
-    user,
-  });
+  return json(
+    {
+      signInUrl: await getSignInUrl(),
+      signUpUrl: await getSignUpUrl(),
+      user,
+    },
+    {
+      headers,
+    },
+  );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ export const loader = authLoader({ returnPathname: '/dashboard' });
 
 Use `authkitLoader` to configure AuthKit for your Remix application routes.
 
-```jsx
-import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node';
+```tsx
+import type { LoaderFunctionArgs } from '@remix-run/node';
 import { authkitLoader } from '@workos-inc/authkit-remix';
 
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) => authkitLoader(args);
+export const loader = (args: LoaderFunctionArgs) => authkitLoader(args);
 
 export function App() {
   return (
@@ -89,12 +89,12 @@ export function App() {
 
 For pages where you want to display a signed-in and signed-out view, use `authkitLoader` to retrieve the user profile from WorkOS. You can pass in additional data by providing a loader function directly to `authkitLoader`.
 
-```jsx
+```tsx
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData, json, Form } from '@remix-run/react';
 import { getSignInUrl, getSignUpUrl, signOut, authkitLoader } from '@workos-inc/authkit-remix';
 
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) => authkitLoader(args, async ({ request, auth }) => {
+export const loader = (args: LoaderFunctionArgs) => authkitLoader(args, async ({ request, auth }) => {
   return json({
     signInUrl: await getSignInUrl();
     signUpUrl: await getSignUpUrl();
@@ -133,8 +133,8 @@ export default function HomePage() {
 
 For pages where a signed-in user is mandatory, you can use the `ensureSignedIn` option:
 
-```jsx
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) => authkitLoader(args, { ensureSignedIn: true });
+```tsx
+export const loader = (args: LoaderFunctionArgs) => authkitLoader(args, { ensureSignedIn: true });
 ```
 
 Enabling `ensureSignedIn` will redirect users to AuthKit if they attempt to access the page without being authenticated.
@@ -147,11 +147,11 @@ Use the `signOut` method to sign out the current logged in user, end the session
 
 Sometimes it is useful to obtain the access token directly, for instance to make API requests to another service.
 
-```jsx
+```tsx
 import type { LoaderFunctionArgs, json } from '@remix-run/node';
 import { withAuth } from '@workos-inc/authkit-remix';
 
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) =>
+export const loader = (args: LoaderFunctionArgs) =>
   authkitLoader(args, async ({ auth }) => {
     const { accessToken } = auth;
 
@@ -175,18 +175,18 @@ export const loader: LoaderFunction = (args: LoaderFunctionArgs) =>
 
 To enable debug logs, pass in the debug flag when using `authkitLoader`.
 
-```js
+```ts
 import { authkitLoader } from '@workos-inc/authkit-remix';
 
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) => authkitLoader(args, { debug: true });
+export const loader = (args: LoaderFunctionArgs) => authkitLoader(args, { debug: true });
 ```
 
 If providing a loader function, you can pass the options object as the third parameter
 
-```js
+```ts
 import { authkitLoader } from '@workos-inc/authkit-remix';
 
-export const loader: LoaderFunction = (args: LoaderFunctionArgs) =>
+export const loader = (args: LoaderFunctionArgs) =>
   authkitLoader(
     args,
     async ({ auth }) => {

--- a/README.md
+++ b/README.md
@@ -80,16 +80,21 @@ import { getSignInUrl, getSignUpUrl, withAuth, signOut } from '@workos-inc/authk
 export async function loader({ request }: LoaderFunctionArgs) {
   // Returns the user, sessionId, organizationId, role, permissions, impersonator and accessToken
   // Additionally, anything in the 'data' object will also be returned
-  return await withAuth(request, {
-    data: {
-      signInUrl: await getSignInUrl(),
-      signUpUrl: await getSignUpUrl(),
+  return await withAuth(
+    request,
+    {
+      data: {
+        signInUrl: await getSignInUrl(),
+        signUpUrl: await getSignUpUrl(),
+      },
     },
-    // Optional headers object
-    headers: {
-      'x-my-header': 'foo',
-    }
-  });
+    {
+      // Optional ResponseInit object
+      headers: {
+        'x-my-header': 'foo',
+      },
+    },
+  );
 }
 
 export async function action({ request }: ActionFunctionArgs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-remix",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-remix",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-remix",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Remix",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -36,6 +36,7 @@ export function authLoader(options: HandleAuthOptions = {}) {
           refreshToken,
           user,
           impersonator,
+          headers: {},
         });
 
         const session = await getSession(cookieName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { authLoader } from './authkit-callback-route.js';
-import { withAuth } from './session.js';
+import { authkitLoader } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 
 export {
@@ -9,5 +9,5 @@ export {
   getSignUpUrl,
   signOut,
   //
-  withAuth,
+  authkitLoader,
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -34,12 +34,22 @@ export interface AuthKitLoaderOptions {
   debug?: boolean;
 }
 
-export interface AuthData {
-  user: User | null;
-  sessionId?: string;
-  accessToken?: string;
-  organizationId?: string;
-  role?: string;
-  permissions?: string[];
-  impersonator?: Impersonator;
+export interface AuthorizedData {
+  user: User;
+  sessionId: string;
+  accessToken: string;
+  organizationId: string | null;
+  role: string | null;
+  permissions: string[];
+  impersonator: Impersonator | null;
+}
+
+export interface UnauthorizedData {
+  user: null;
+  sessionId: null;
+  accessToken: null;
+  organizationId: null;
+  role: null;
+  permissions: null;
+  impersonator: null;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,11 +8,13 @@ export interface Impersonator {
   email: string;
   reason: string | null;
 }
+
 export interface Session {
   accessToken: string;
   refreshToken: string;
   user: User;
   impersonator?: Impersonator;
+  headers: Record<string, string>;
 }
 
 export interface UserInfo {
@@ -23,7 +25,9 @@ export interface UserInfo {
   permissions?: string[];
   impersonator?: Impersonator;
   accessToken: string;
+  headers: Record<string, string>;
 }
+
 export interface NoUserInfo {
   user: null;
   sessionId?: undefined;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,12 +29,17 @@ export interface GetAuthURLOptions {
   returnPathname?: string;
 }
 
-export interface AuthkitMiddlewareAuth {
-  enabled: boolean;
-  unauthenticatedPaths: string[];
+export interface AuthKitLoaderOptions {
+  ensureSignedIn?: boolean;
+  debug?: boolean;
 }
 
-export interface AuthkitMiddlewareOptions {
-  debug?: boolean;
-  middlewareAuth?: AuthkitMiddlewareAuth;
+export interface AuthData {
+  user: User | null;
+  sessionId?: string;
+  accessToken?: string;
+  organizationId?: string;
+  role?: string;
+  permissions?: string[];
+  impersonator?: Impersonator;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,25 +17,6 @@ export interface Session {
   headers: Record<string, string>;
 }
 
-export interface UserInfo {
-  user: User;
-  sessionId: string;
-  organizationId?: string;
-  role?: string;
-  permissions?: string[];
-  impersonator?: Impersonator;
-  accessToken: string;
-  headers: Record<string, string>;
-}
-
-export interface NoUserInfo {
-  user: null;
-  sessionId?: undefined;
-  organizationId?: undefined;
-  role?: undefined;
-  impersonator?: undefined;
-}
-
 export interface AccessToken {
   sid: string;
   org_id?: string;

--- a/src/session.ts
+++ b/src/session.ts
@@ -80,29 +80,29 @@ type AuthLoader<Data> = (
 
 type AuthorizedAuthLoader<Data> = (args: LoaderFunctionArgs & { auth: AuthorizedData }) => LoaderReturnValue<Data>;
 
-export async function authkitLoader(
+async function authkitLoader(
   loaderArgs: LoaderFunctionArgs,
   options: AuthKitLoaderOptions & { ensureSignedIn: true },
 ): Promise<TypedResponse<AuthorizedData>>;
 
-export async function authkitLoader(
+async function authkitLoader(
   loaderArgs: LoaderFunctionArgs,
   options?: AuthKitLoaderOptions,
 ): Promise<TypedResponse<AuthorizedData | UnauthorizedData>>;
 
-export async function authkitLoader<Data = unknown>(
+async function authkitLoader<Data = unknown>(
   loaderArgs: LoaderFunctionArgs,
   loader: AuthorizedAuthLoader<Data>,
   options: AuthKitLoaderOptions & { ensureSignedIn: true },
 ): Promise<TypedResponse<Data & AuthorizedData>>;
 
-export async function authkitLoader<Data = unknown>(
+async function authkitLoader<Data = unknown>(
   loaderArgs: LoaderFunctionArgs,
   loader: AuthLoader<Data>,
   options?: AuthKitLoaderOptions,
 ): Promise<TypedResponse<Data & (AuthorizedData | UnauthorizedData)>>;
 
-export async function authkitLoader<Data = unknown>(
+async function authkitLoader<Data = unknown>(
   loaderArgs: LoaderFunctionArgs,
   loaderOrOptions?: AuthLoader<Data> | AuthorizedAuthLoader<Data> | AuthKitLoaderOptions,
   options: AuthKitLoaderOptions = {},
@@ -253,4 +253,4 @@ async function verifyAccessToken(accessToken: string) {
   }
 }
 
-export { encryptSession, terminateSession };
+export { encryptSession, terminateSession, authkitLoader };

--- a/src/session.ts
+++ b/src/session.ts
@@ -132,12 +132,13 @@ async function withAuth(
 }
 
 async function terminateSession(request: Request) {
-  const cookieSession = await getSession(request.headers.get('Cookie'));
+  const encryptedSession = await getSession(request.headers.get('Cookie'));
+  const { accessToken } = (await getSessionFromCookie(request.headers.get('Cookie'))) as Session;
 
-  const { sessionId } = getClaimsFromAccessToken(cookieSession.get('accessToken'));
+  const { sessionId } = getClaimsFromAccessToken(accessToken);
 
   const headers = {
-    'Set-Cookie': await destroySession(cookieSession),
+    'Set-Cookie': await destroySession(encryptedSession),
   };
 
   if (sessionId) {
@@ -145,6 +146,7 @@ async function terminateSession(request: Request) {
       headers,
     });
   }
+
   return redirect('/', {
     headers,
   });

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_HTTPS, WORKOS_API_KEY, WORKOS_API_PORT } from './env-variables.js';
 
-const VERSION = '0.2.1';
+const VERSION = '0.3.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-remix/issues/7

When re-authenticating via refresh token, the new session plus refresh token wasn't being saved correctly. This meant that if you re-authed via refresh token, then refreshed the page you'd get a stale token error and have your session wiped.