### PR TITLE
Adds the sealed session to the auth data

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Sometimes it is useful to obtain the access token directly, for instance to make
 ```tsx
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { withAuth } from '@workos-inc/authkit-remix';
+import { authkitLoader } from '@workos-inc/authkit-remix';
 
 export const loader = (args: LoaderFunctionArgs) =>
   authkitLoader(args, async ({ auth }) => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,6 +42,7 @@ export interface AuthorizedData {
   role: string | null;
   permissions: string[];
   impersonator: Impersonator | null;
+  sealedSession: string;
 }
 
 export interface UnauthorizedData {
@@ -52,4 +53,5 @@ export interface UnauthorizedData {
   role: null;
   permissions: null;
   impersonator: null;
+  sealedSession: null;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -133,6 +133,7 @@ async function authkitLoader<Data = unknown>(
       permissions: null,
       role: null,
       sessionId: null,
+      sealedSession: null,
     };
 
     return await handleAuthLoader(loader, loaderArgs, auth);
@@ -145,6 +146,8 @@ async function authkitLoader<Data = unknown>(
     permissions = [],
   } = getClaimsFromAccessToken(session.accessToken);
 
+  const cookieSession = await getSession(request.headers.get('Cookie'));
+
   const auth: AuthorizedData = {
     user: session.user,
     sessionId,
@@ -153,6 +156,7 @@ async function authkitLoader<Data = unknown>(
     role,
     permissions,
     impersonator: session.impersonator ?? null,
+    sealedSession: cookieSession.get('jwt'),
   };
 
   return await handleAuthLoader(loader, loaderArgs, auth, session);


### PR DESCRIPTION
Sometimes you might want to pass the sealed session to a backend to perform auth features there. Because Remix mints its sessions as JWTs, it means you can't get the sealed session directly from the browser cookie.

This cuts out the middleman and explicitly passes the sealed session in the loader data response.