### PR TITLE
fix: callback route fails when state is "null"

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -13,7 +13,7 @@ export function authLoader(options: HandleAuthOptions = {}) {
 
     const code = url.searchParams.get('code');
     const state = url.searchParams.get('state');
-    let returnPathname = state ? JSON.parse(atob(state)).returnPathname : null;
+    let returnPathname = state && stage !== "null" ? JSON.parse(atob(state)).returnPathname : null;
 
     if (code) {
       try {


### PR DESCRIPTION
A default WorkOS setup will set the `state` query param to `null`, resulting in an exception in the callback.

`JSON.parse(atob("null"))` throws

```
VM335:1 Uncaught SyntaxError: Unexpected token '', "ée" is not valid JSON
    at JSON.parse (<anonymous>)
    at <anonymous>:1:6
```