### PR TITLE
Move `oauthTokens` out of `Session` and make available via `authLoader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,8 @@ import { authkitLoader } from '@workos-inc/authkit-remix';
 export const loader = (args: LoaderFunctionArgs) => authkitLoader(args);
 
 export function App() {
-
   // Retrieves the user from the session or returns `null` if no user is signed in
-  // Other supported values include sessionId, accessToken, organizationId, role, permissions, impersonator and oauthTokens
+  // Other supported values include `sessionId`, `accessToken`, `organizationId`, `role`, `permissions`, and `impersonator`.
   const { user, signInUrl, signUpUrl } = useLoaderData<typeof loader>();
 
   return (
@@ -114,7 +113,6 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function HomePage() {
-
   const { user, signInUrl, signUpUrl } = useLoaderData<typeof loader>();
 
   if (!user) {

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ You can also control the pathname the user will be sent to after signing-in by p
 export const loader = authLoader({ returnPathname: '/dashboard' });
 ```
 
+If your application needs to persist `oauthTokens` or other auth-related information after the callback is successful, you can pass an `onSuccess` option:
+
+```ts
+export const loader = authLoader({
+  onSuccess: async ({ oauthTokens }) => {
+    await saveToDatabase(oauthTokens);
+  },
+});
+```
+
 ## Usage
 
 ### Access authentication data in your Remix application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-remix",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-remix",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.31.0",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -54,8 +54,9 @@ export function authLoader(
           url.pathname = returnPathname;
         }
 
-        // The refreshToken and oauthTokens should never be accesible publicly, hence why we encrypt it in the cookie session
-        // Alternatively you could persist the refresh token in a backend database
+        // The refreshToken should never be accesible publicly, hence why we encrypt it
+        // in the cookie session. Alternatively you could persist the refresh token in a
+        // backend database.
         const encryptedSession = await encryptSession({
           accessToken,
           refreshToken,

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -61,7 +61,6 @@ export function authLoader(
           refreshToken,
           user,
           impersonator,
-          oauthTokens,
           headers: {},
         });
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -1,25 +1,13 @@
-import { HandleAuthOptions, Impersonator } from './interfaces.js';
+import { HandleAuthOptions } from './interfaces.js';
 import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { workos } from './workos.js';
 import { encryptSession } from './session.js';
 import { getSession, commitSession, cookieName } from './cookie.js';
 import { redirect, json, LoaderFunctionArgs } from '@remix-run/node';
-import { OauthTokens, User } from '@workos-inc/node';
 
-export interface AuthLoaderSuccessData {
-  accessToken: string;
-  impersonator: Impersonator | null;
-  oauthTokens: OauthTokens | null;
-  refreshToken: string;
-  user: User;
-}
-
-export function authLoader(
-  options: HandleAuthOptions = {},
-  onSuccess?: (data: AuthLoaderSuccessData) => void | Promise<void>,
-) {
+export function authLoader(options: HandleAuthOptions = {}) {
   return async function loader({ request }: LoaderFunctionArgs) {
-    const { returnPathname: returnPathnameOption = '/' } = options;
+    const { returnPathname: returnPathnameOption = '/', onSuccess } = options;
 
     const url = new URL(request.url);
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,7 +14,6 @@ export interface Session {
   refreshToken: string;
   user: User;
   impersonator?: Impersonator;
-  oauthTokens?: OauthTokens;
   headers: Record<string, string>;
 }
 
@@ -43,7 +42,6 @@ export interface AuthorizedData {
   role: string | null;
   permissions: string[];
   impersonator: Impersonator | null;
-  oauthTokens: OauthTokens | null;
   sealedSession: string;
 }
 
@@ -55,6 +53,5 @@ export interface UnauthorizedData {
   role: null;
   permissions: null;
   impersonator: null;
-  oauthTokens: null;
   sealedSession: null;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,15 @@ import { OauthTokens, User } from '@workos-inc/node';
 
 export interface HandleAuthOptions {
   returnPathname?: string;
+  onSuccess?: (data: AuthLoaderSuccessData) => void | Promise<void>;
+}
+
+export interface AuthLoaderSuccessData {
+  accessToken: string;
+  impersonator: Impersonator | null;
+  oauthTokens: OauthTokens | null;
+  refreshToken: string;
+  user: User;
 }
 
 export interface Impersonator {

--- a/src/session.ts
+++ b/src/session.ts
@@ -42,7 +42,6 @@ async function updateSession(request: Request, debug: boolean) {
       refreshToken,
       user: session.user,
       impersonator: session.impersonator,
-      oauthTokens: session.oauthTokens,
       headers: {},
     };
 
@@ -130,7 +129,6 @@ async function authkitLoader<Data = unknown>(
       user: null,
       accessToken: null,
       impersonator: null,
-      oauthTokens: null,
       organizationId: null,
       permissions: null,
       role: null,
@@ -158,7 +156,6 @@ async function authkitLoader<Data = unknown>(
     role,
     permissions,
     impersonator: session.impersonator ?? null,
-    oauthTokens: session.oauthTokens ?? null,
     sealedSession: cookieSession.get('jwt'),
   };
 


### PR DESCRIPTION
Currently we are taking the `oauthTokens` received during the code exchange, which happens as part of the `authLoader` implementation, and serializing them into the `Session`. Later develops can access them via the `authKitLoader`, which is retrieving them out of the serialized cookie.

This is causing issues as the `oauthTokens` payload can be large enough that it pushes the cookies size of the traditional limit of 4KB.

Instead of storing these tokens in the session, this branch proposes making them only available as part of the initial callback. Developers who need access to the underlying OAuth provider's tokens and API will be responsible for persisting them in their own data store for later usage.

Using the new `authLoader` callback would look something like this:

```ts
import { authLoader } from '@workos-inc/authkit-remix';

export const loader = authLoader({ returnPathname: '/dashboard' }, async (authData) => {
  await someDataStore.save(authData.oauthTokens);
});
```