### PR TITLE
fix: pass through non-JSON responses without modification in loader wrapper

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import { sealData, unsealData } from 'iron-session';
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { getConfig } from './config.js';
 import { configureSessionStorage, getSessionStorage } from './sessionStorage.js';
-import { isResponse, isRedirect } from './utils.js';
+import { isResponse, isRedirect, isJsonResponse } from './utils.js';
 
 // must be a type since this is a subtype of response
 // interfaces must conform to the types they extend
@@ -309,14 +309,16 @@ async function handleAuthLoader(
     }
 
     const newResponse = new Response(loaderResult.body, loaderResult);
-    const responseData = await newResponse.json();
 
-    // Set the content type in case the user returned a Response instead of the
-    // json helper method
-    newResponse.headers.set('Content-Type', 'application/json; charset=utf-8');
     if (session) {
       newResponse.headers.append('Set-Cookie', session.headers['Set-Cookie']);
     }
+
+    if (!isJsonResponse(newResponse)) {
+      return newResponse;
+    }
+
+    const responseData = await newResponse.json();
 
     return data({ ...responseData, ...auth }, newResponse);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,8 @@ export function isRedirect(res: Response) {
  * @returns True if the response is a JSON response.
  */
 export function isJsonResponse(res: Response): boolean {
-  return !!res.headers.get('Content-Type')?.includes('application/json');
+  const contentType = res.headers.get('Content-Type')?.toLowerCase();
+  return !!contentType?.includes('application/json');
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,16 @@ export function isRedirect(res: Response) {
 }
 
 /**
+ * Returns true if the response is a JSON response.
+ * This is determined by checking if the Content-Type header includes 'application/json'.
+ * @param res - The response to check.
+ * @returns True if the response is a JSON response.
+ */
+export function isJsonResponse(res: Response): boolean {
+  return !!res.headers.get('Content-Type')?.includes('application/json');
+}
+
+/**
  * Returns true if the response is a response.
  * @param response - The response to check.
  * @returns True if the response is a response.


### PR DESCRIPTION
The library is incorrectly expecting all responses passed through our loader wrapper to be returning JSON. This diff adds a check and passes through non-JSON responses without modifying the response body.