### PR TITLE
Add returnTo optional argument to signOut method

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ Enabling `ensureSignedIn` will redirect users to AuthKit if they attempt to acce
 
 Use the `signOut` method to sign out the current logged in user, end the session, and redirect to your app's homepage. The homepage redirect is set in your WorkOS dashboard settings under "Redirect".
 
+If you would like to specify where a user is redirected, an optional `returnTo` argument can be passed. Allowed values are configured in the WorkOS Dashboard under _[Logout redirects](https://workos.com/docs/user-management/sessions/configuring-sessions/logout-redirect)_.
+
+```ts
+export async function action({ request }: ActionFunctionArgs) {
+  // Called when the form in SignInButton is submitted
+  return await signOut(request, 'https://example.com');
+}
+```
+
 ### Get the access token
 
 Sometimes it is useful to obtain the access token directly, for instance to make API requests to another service.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ If you would like to specify where a user is redirected, an optional `returnTo` 
 ```ts
 export async function action({ request }: ActionFunctionArgs) {
   // Called when the form in SignInButton is submitted
-  return await signOut(request, 'https://example.com');
+  return await signOut(request, { returnTo: 'https://example.com' });
 }
 ```
 

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -66,9 +66,9 @@ describe('auth', () => {
     it('should return a response with returnTo', async () => {
       const request = new Request('https://example.com');
       const returnTo = '/dashboard';
-      const response = await signOut(request, returnTo);
+      const response = await signOut(request, { returnTo });
       expect(response).toBeInstanceOf(Response);
-      expect(terminateSession).toHaveBeenCalledWith(request, returnTo);
+      expect(terminateSession).toHaveBeenCalledWith(request, { returnTo });
     });
   });
 

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -60,7 +60,15 @@ describe('auth', () => {
       const request = new Request('https://example.com');
       const response = await signOut(request);
       expect(response).toBeInstanceOf(Response);
-      expect(terminateSession).toHaveBeenCalledWith(request);
+      expect(terminateSession).toHaveBeenCalledWith(request, undefined);
+    });
+
+    it('should return a response with returnTo', async () => {
+      const request = new Request('https://example.com');
+      const returnTo = '/dashboard';
+      const response = await signOut(request, returnTo);
+      expect(response).toBeInstanceOf(Response);
+      expect(terminateSession).toHaveBeenCalledWith(request, returnTo);
     });
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,8 +10,8 @@ export async function getSignUpUrl(returnPathname?: string) {
   return getAuthorizationUrl({ returnPathname, screenHint: 'sign-up' });
 }
 
-export async function signOut(request: Request) {
-  return await terminateSession(request);
+export async function signOut(request: Request, returnTo?: string) {
+  return await terminateSession(request, returnTo);
 }
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,8 +10,8 @@ export async function getSignUpUrl(returnPathname?: string) {
   return getAuthorizationUrl({ returnPathname, screenHint: 'sign-up' });
 }
 
-export async function signOut(request: Request, returnTo?: string) {
-  return await terminateSession(request, returnTo);
+export async function signOut(request: Request, options?: { returnTo?: string }) {
+  return await terminateSession(request, options);
 }
 
 /**

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -208,7 +208,7 @@ describe('session', () => {
       // Mock decodeJwt to return no sessionId
       (jose.decodeJwt as jest.Mock).mockReturnValueOnce({});
 
-      const response = await terminateSession(createMockRequest(), '/login');
+      const response = await terminateSession(createMockRequest(), { returnTo: '/login' });
 
       expect(response instanceof Response).toBe(true);
       expect(response.status).toBe(302);

--- a/src/session.ts
+++ b/src/session.ts
@@ -393,7 +393,7 @@ async function handleAuthLoader(
   return data({ ...loaderResult, ...auth }, session ? { headers: { ...session.headers } } : undefined);
 }
 
-export async function terminateSession(request: Request, returnTo?: string) {
+export async function terminateSession(request: Request, { returnTo }: { returnTo?: string } = {}) {
   const { getSession, destroySession } = await getSessionStorage();
   const encryptedSession = await getSession(request.headers.get('Cookie'));
   const { accessToken } = (await getSessionFromCookie(

--- a/src/session.ts
+++ b/src/session.ts
@@ -393,7 +393,7 @@ async function handleAuthLoader(
   return data({ ...loaderResult, ...auth }, session ? { headers: { ...session.headers } } : undefined);
 }
 
-export async function terminateSession(request: Request) {
+export async function terminateSession(request: Request, returnTo?: string) {
   const { getSession, destroySession } = await getSessionStorage();
   const encryptedSession = await getSession(request.headers.get('Cookie'));
   const { accessToken } = (await getSessionFromCookie(
@@ -408,12 +408,12 @@ export async function terminateSession(request: Request) {
   };
 
   if (sessionId) {
-    return redirect(getWorkOS().userManagement.getLogoutUrl({ sessionId }), {
+    return redirect(getWorkOS().userManagement.getLogoutUrl({ sessionId, returnTo }), {
       headers,
     });
   }
 
-  return redirect('/', {
+  return redirect(returnTo ?? '/', {
     headers,
   });
 }


### PR DESCRIPTION
If you would like to specify where a user is redirected, an optional `returnTo` argument can be passed. Allowed values are configured in the WorkOS Dashboard under _[Logout redirects](https://workos.com/docs/user-management/sessions/configuring-sessions/logout-redirect)_.

```ts
export async function action({ request }: ActionFunctionArgs) {
  // Called when the form in SignInButton is submitted
  return await signOut(request, { returnTo: 'https://example.com' });
}
```



https://github.com/user-attachments/assets/f5b44c26-cb4b-474a-8af1-f50ddca94495