### PR TITLE
Add Session Refresh Callbacks

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { SessionStorage, SessionIdStorageStrategy, data } from '@remix-run/node';
+import type { SessionStorage, SessionIdStorageStrategy, data, SessionData } from '@remix-run/node';
 import type { OauthTokens, User } from '@workos-inc/node';
 
 export type DataWithResponseInit<T> = ReturnType<typeof data<T>>;
@@ -14,6 +14,19 @@ export interface AuthLoaderSuccessData {
   oauthTokens: OauthTokens | null;
   refreshToken: string;
   user: User;
+}
+
+export interface RefreshErrorOptions {
+  error: unknown;
+  request: Request;
+  sessionData: SessionData;
+}
+
+export interface RefreshSuccessOptions {
+  accessToken: string;
+  user: User;
+  impersonator: Impersonator | null;
+  organizationId: string | null;
 }
 
 export interface Impersonator {
@@ -40,6 +53,9 @@ export interface AccessToken {
 export type AuthKitLoaderOptions = {
   ensureSignedIn?: boolean;
   debug?: boolean;
+  onSessionRefreshError?: (options: RefreshErrorOptions) => void | Response | Promise<void | Response>;
+  onSessionRefreshSuccess?: (options: RefreshSuccessOptions) => void | Promise<void>;
+  redirectToAuthOnRefreshFailure?: boolean;
 } & (
   | {
       storage?: never;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,7 +55,6 @@ export type AuthKitLoaderOptions = {
   debug?: boolean;
   onSessionRefreshError?: (options: RefreshErrorOptions) => void | Response | Promise<void | Response>;
   onSessionRefreshSuccess?: (options: RefreshSuccessOptions) => void | Promise<void>;
-  redirectToAuthOnRefreshFailure?: boolean;
 } & (
   | {
       storage?: never;

--- a/src/session.ts
+++ b/src/session.ts
@@ -343,8 +343,7 @@ export async function authkitLoader<Data = unknown>(
     const cookieSession = await getSession(request.headers.get('Cookie'));
     const { impersonator = null } = session;
 
-    // Session refresh was successful if the session was refreshed
-    // Call success callback if provided
+    // checking for 'headers' in session determines if the session was refreshed or not
     if (onSessionRefreshSuccess && 'headers' in session) {
       await onSessionRefreshSuccess({
         accessToken: session.accessToken,
@@ -368,11 +367,9 @@ export async function authkitLoader<Data = unknown>(
 
     return await handleAuthLoader(loader, loaderArgs, auth, session);
   } catch (error) {
-    // Handle session refresh errors
     if (error instanceof SessionRefreshError) {
       const cookieSession = await getSession(request.headers.get('Cookie'));
 
-      // If refresh error callback provided, execute it
       if (onSessionRefreshError) {
         try {
           const result = await onSessionRefreshError({
@@ -381,7 +378,6 @@ export async function authkitLoader<Data = unknown>(
             sessionData: cookieSession,
           });
 
-          // If callback returned a Response, use it
           if (result instanceof Response) {
             return result;
           }

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,6 +22,13 @@ export type TypedResponse<T> = Response & {
   json(): Promise<T>;
 };
 
+export class SessionRefreshError extends Error {
+  constructor(cause: unknown) {
+    super('Session refresh error', { cause });
+    this.name = 'SessionRefreshError';
+  }
+}
+
 /**
  * This function is used to refresh the session by using the refresh token.
  * It will authenticate the user with the refresh token and return a new session object.
@@ -89,7 +96,7 @@ export async function refreshSession(request: Request, { organizationId }: { org
 
 async function updateSession(request: Request, debug: boolean) {
   const session = await getSessionFromCookie(request.headers.get('Cookie') as string);
-  const { commitSession, getSession, destroySession } = await getSessionStorage();
+  const { commitSession, getSession } = await getSessionStorage();
 
   // If no session, just continue
   if (!session) {
@@ -138,13 +145,7 @@ async function updateSession(request: Request, debug: boolean) {
     // istanbul ignore next
     if (debug) console.log('Failed to refresh. Deleting cookie and redirecting.', e);
 
-    const cookieSession = await getSession(request.headers.get('Cookie'));
-
-    throw redirect('/', {
-      headers: {
-        'Set-Cookie': await destroySession(cookieSession),
-      },
-    });
+    throw new SessionRefreshError(e);
   }
 }
 
@@ -287,6 +288,8 @@ export async function authkitLoader<Data = unknown>(
   const {
     ensureSignedIn = false,
     debug = false,
+    onSessionRefreshSuccess,
+    onSessionRefreshError,
     storage,
     cookie,
   } = typeof loaderOrOptions === 'object' ? loaderOrOptions : options;
@@ -295,62 +298,111 @@ export async function authkitLoader<Data = unknown>(
   const { getSession, destroySession } = await configureSessionStorage({ storage, cookieName });
 
   const { request } = loaderArgs;
-  const session = await updateSession(request, debug);
 
-  if (!session) {
-    if (ensureSignedIn) {
-      const returnPathname = getReturnPathname(request.url);
+  try {
+    // Try to get session, this might throw SessionRefreshError
+    const session = await updateSession(request, debug);
+
+    if (!session) {
+      // No session found case (not authenticated)
+      if (ensureSignedIn) {
+        const returnPathname = getReturnPathname(request.url);
+        const cookieSession = await getSession(request.headers.get('Cookie'));
+
+        throw redirect(await getAuthorizationUrl({ returnPathname }), {
+          headers: {
+            'Set-Cookie': await destroySession(cookieSession),
+          },
+        });
+      }
+
+      const auth: UnauthorizedData = {
+        user: null,
+        accessToken: null,
+        impersonator: null,
+        organizationId: null,
+        permissions: null,
+        entitlements: null,
+        role: null,
+        sessionId: null,
+        sealedSession: null,
+      };
+
+      return await handleAuthLoader(loader, loaderArgs, auth);
+    }
+
+    // Session found and valid (or refreshed successfully)
+    const {
+      sessionId,
+      organizationId = null,
+      role = null,
+      permissions = [],
+      entitlements = [],
+    } = getClaimsFromAccessToken(session.accessToken);
+
+    const cookieSession = await getSession(request.headers.get('Cookie'));
+    const { impersonator = null } = session;
+
+    // Session refresh was successful if the session was refreshed
+    // Call success callback if provided
+    if (onSessionRefreshSuccess && 'headers' in session) {
+      await onSessionRefreshSuccess({
+        accessToken: session.accessToken,
+        user: session.user,
+        impersonator,
+        organizationId,
+      });
+    }
+
+    const auth: AuthorizedData = {
+      user: session.user,
+      sessionId,
+      accessToken: session.accessToken,
+      organizationId,
+      role,
+      permissions,
+      entitlements,
+      impersonator,
+      sealedSession: cookieSession.get('jwt'),
+    };
+
+    return await handleAuthLoader(loader, loaderArgs, auth, session);
+  } catch (error) {
+    // Handle session refresh errors
+    if (error instanceof SessionRefreshError) {
       const cookieSession = await getSession(request.headers.get('Cookie'));
 
-      throw redirect(await getAuthorizationUrl({ returnPathname }), {
+      // If refresh error callback provided, execute it
+      if (onSessionRefreshError) {
+        try {
+          const result = await onSessionRefreshError({
+            error: error.cause,
+            request,
+            sessionData: cookieSession,
+          });
+
+          // If callback returned a Response, use it
+          if (result instanceof Response) {
+            return result;
+          }
+        } catch (callbackError) {
+          // If callback throws a Response (like redirect), propagate it
+          if (callbackError instanceof Response) {
+            throw callbackError;
+          }
+        }
+      }
+
+      throw redirect('/', {
         headers: {
           'Set-Cookie': await destroySession(cookieSession),
         },
       });
     }
 
-    const auth: UnauthorizedData = {
-      user: null,
-      accessToken: null,
-      impersonator: null,
-      organizationId: null,
-      permissions: null,
-      entitlements: null,
-      role: null,
-      sessionId: null,
-      sealedSession: null,
-    };
-
-    return await handleAuthLoader(loader, loaderArgs, auth);
+    // Propagate other errors
+    throw error;
   }
-
-  // istanbul ignore next
-  const {
-    sessionId,
-    organizationId = null,
-    role = null,
-    permissions = [],
-    entitlements = [],
-  } = getClaimsFromAccessToken(session.accessToken);
-
-  const cookieSession = await getSession(request.headers.get('Cookie'));
-
-  // istanbul ignore next
-  const { impersonator = null } = session;
-
-  const auth: AuthorizedData = {
-    user: session.user,
-    sessionId,
-    accessToken: session.accessToken,
-    organizationId,
-    role,
-    permissions,
-    entitlements,
-    impersonator,
-    sealedSession: cookieSession.get('jwt'),
-  };
-
-  return await handleAuthLoader(loader, loaderArgs, auth, session);
 }
 
 async function handleAuthLoader(


### PR DESCRIPTION
## Summary

This PR adds callbacks for session refresh success and failure in the AuthKit Remix SDK, providing a more flexible and developer-friendly approach to handling session refreshes.


## Problem

Previously, when a session refresh failed, the SDK would simply delete the cookie and redirect the user to the root path (/). This hard-coded behavior provided no visibility into why the refresh failed and no way for developers to customize the error handling flow.

## Solution

This PR introduces:

- `onSessionRefreshSuccess` callback - Called when a session is successfully refreshed
- `onSessionRefreshError` callback - Called when a session refresh fails

These callbacks allow developers to implement custom error handling, logging, analytics, and user messaging around session lifecycle events.

## Implementation Details

- Created a `SessionRefreshError` class to properly identify refresh failures
- Modified the session refresh flow to use try/catch pattern

## Example Usage
```typescript
export const loader = async ({ request }) => 
  authkitLoader({ request }, async ({ auth }) => {
    return json({ user: auth.user });
  }, {
    onSessionRefreshError: async ({ error, request, sessionData }) => {
      // Log the error to your monitoring service
      console.error("Session refresh failed:", error);
      
      // You can throw a redirect to a custom error page
      throw redirect("/auth/session-expired");
      
      // Or return a custom response
      // return data({ error: "Your session expired" }, { status: 401 });
    },
    
    onSessionRefreshSuccess: async ({ accessToken, user, organizationId }) => {
      // Track successful refresh
      console.log("Session refreshed for user:", user.id);
    }
  });
```

## Backward Compatibility

To maintain backward compatibility, the default behavior (redirect to `/` and delete cookie) is preserved when no onSessionRefreshError callback is provided.…lbacks in authkit loader