### PR TITLE
Add a withAuth helper method

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -54,6 +54,8 @@ export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoU
   } = getClaimsFromAccessToken(session.accessToken);
 
   if (Date.now() >= exp * 1000) {
+    // The access token is expired. This function does not handle token refresh.
+    // Ensure that token refresh is implemented in the parent/root loader as documented.
     console.warn('Access token expired for user');
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,8 @@
-import { data, redirect } from '@remix-run/node';
+import { LoaderFunctionArgs, data, redirect } from '@remix-run/node';
 import { getAuthorizationUrl } from './get-authorization-url.js';
-import { refreshSession, terminateSession } from './session.js';
+import { NoUserInfo, UserInfo } from './interfaces.js';
+import { getClaimsFromAccessToken, getSessionFromCookie, refreshSession, terminateSession } from './session.js';
+import { getConfig } from './config.js';
 
 export async function getSignInUrl(returnPathname?: string) {
   return getAuthorizationUrl({ returnPathname, screenHint: 'sign-in' });
@@ -12,6 +14,59 @@ export async function getSignUpUrl(returnPathname?: string) {
 
 export async function signOut(request: Request, options?: { returnTo?: string }) {
   return await terminateSession(request, options);
+}
+
+/**
+ * Given a loader's args, this function will check if the user is authenticated.
+ * If the user is authenticated, it will return their information.
+ * If the user is not authenticated, it will return an object with user set to null.
+ * IMPORTANT: This authkitLoader must be used in a parent/root loader
+ * to handle session refresh and cookie management.
+ * @param args - The loader's arguments.
+ * @returns An object containing user information
+ */
+export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoUserInfo> {
+  const { request } = args;
+  const cookieHeader = request.headers.get('Cookie') as string;
+  const cookieName = getConfig('cookieName');
+
+  // Simple check without environment detection
+  if (!cookieHeader || !cookieHeader.includes(cookieName)) {
+    console.warn(
+      `[AuthKit] No session cookie "${cookieName}" found. ` + `Make sure authkitLoader is used in a parent/root route.`,
+    );
+  }
+  const session = await getSessionFromCookie(cookieHeader);
+
+  if (!session?.accessToken) {
+    return {
+      user: null,
+    };
+  }
+
+  const {
+    sessionId,
+    organizationId,
+    permissions,
+    entitlements,
+    role,
+    exp = 0,
+  } = getClaimsFromAccessToken(session.accessToken);
+
+  if (Date.now() >= exp * 1000) {
+    console.warn('Access token expired for user');
+  }
+
+  return {
+    user: session.user,
+    sessionId,
+    organizationId,
+    role,
+    permissions,
+    entitlements,
+    impersonator: session.impersonator,
+    accessToken: session.accessToken,
+  };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
+import { getSignInUrl, getSignUpUrl, signOut, withAuth } from './auth.js';
 import { authLoader } from './authkit-callback-route.js';
 import { configure, getConfig } from './config.js';
 import { authkitLoader } from './session.js';
@@ -15,4 +15,5 @@ export {
   configure,
   getConfig,
   getWorkOS,
+  withAuth,
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,6 +37,28 @@ export interface AccessToken {
   entitlements?: string[];
 }
 
+export interface UserInfo {
+  user: User;
+  sessionId: string;
+  organizationId?: string;
+  role?: string;
+  permissions?: string[];
+  entitlements?: string[];
+  impersonator?: Impersonator;
+  accessToken: string;
+}
+
+export interface NoUserInfo {
+  user: null;
+  sessionId?: undefined;
+  organizationId?: undefined;
+  role?: undefined;
+  permissions?: undefined;
+  entitlements?: undefined;
+  impersonator?: undefined;
+  accessToken?: undefined;
+}
+
 export type AuthKitLoaderOptions = {
   ensureSignedIn?: boolean;
   debug?: boolean;

--- a/src/session.ts
+++ b/src/session.ts
@@ -418,16 +418,20 @@ export async function terminateSession(request: Request, { returnTo }: { returnT
   });
 }
 
-function getClaimsFromAccessToken(accessToken: string) {
+export function getClaimsFromAccessToken(accessToken: string) {
   const {
     sid: sessionId,
     org_id: organizationId,
     role,
     permissions,
     entitlements,
+    exp,
+    iss,
   } = decodeJwt<AccessToken>(accessToken);
 
   return {
+    iss,
+    exp,
     sessionId,
     organizationId,
     role,
@@ -436,7 +440,7 @@ function getClaimsFromAccessToken(accessToken: string) {
   };
 }
 
-async function getSessionFromCookie(cookie: string, session?: SessionData) {
+export async function getSessionFromCookie(cookie: string, session?: SessionData) {
   const { getSession } = await getSessionStorage();
   if (!session) {
     session = await getSession(cookie);


### PR DESCRIPTION
# Add new `withAuth` function for simplified auth data access

## Purpose

This PR adds a new `withAuth` function that provides a simpler way to access authentication data in child routes without wrapping loaders. It complements the existing `authkitLoader` pattern rather than replacing it.

## Implementation

- Added `withAuth` function that accepts `LoaderFunctionArgs` and returns auth data
- Function reads from the session cookie without handling refresh operations
- Added developer warning when no session cookie is found
- Added token expiration warning to help detect potential timing issues
- Maintained the same auth data structure returned by `authkitLoader`

## Benefits

- Reduces boilerplate in child routes that only need to read auth data
- Simplifies access to user info, permissions, roles and tokens
- Improves code readability by separating auth data access from loader logic
- Works alongside existing patterns without breaking changes

## Usage Example

```typescript
export async function loader({ request }: LoaderFunctionArgs) {
  const { user, permissions } = await withAuth({ request });
  
  // Use auth data without wrapping the entire loader
  const data = await fetchSomeData();
  
  return json({ data });
}
```

## Design Considerations

The `withAuth` function assumes that `authkitLoader` is used in a parent/root route to handle session refresh. It focuses on reading auth data rather than maintaining the authentication lifecycle.

Fixes #19 