### PR TITLE
Allow configuring session storage on callback route

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -2,13 +2,14 @@ import { LoaderFunctionArgs, data, redirect } from '@remix-run/node';
 import { getConfig } from './config.js';
 import { HandleAuthOptions } from './interfaces.js';
 import { encryptSession } from './session.js';
-import { getSessionStorage } from './sessionStorage.js';
+import { configureSessionStorage } from './sessionStorage.js';
 import { getWorkOS } from './workos.js';
 
 export function authLoader(options: HandleAuthOptions = {}) {
   return async function loader({ request }: LoaderFunctionArgs) {
-    const { getSession, commitSession, cookieName } = await getSessionStorage();
-    const { returnPathname: returnPathnameOption = '/', onSuccess } = options;
+    const { storage, cookie, returnPathname: returnPathnameOption = '/', onSuccess } = options;
+    const cookieName = cookie?.name ?? getConfig('cookieName');
+    const { getSession, commitSession } = await configureSessionStorage({ storage, cookieName });
 
     const url = new URL(request.url);
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,10 +3,19 @@ import type { OauthTokens, User } from '@workos-inc/node';
 
 export type DataWithResponseInit<T> = ReturnType<typeof data<T>>;
 
-export interface HandleAuthOptions {
+export type HandleAuthOptions = {
   returnPathname?: string;
   onSuccess?: (data: AuthLoaderSuccessData) => void | Promise<void>;
-}
+} & (
+  | {
+      storage?: never;
+      cookie?: SessionIdStorageStrategy['cookie'];
+    }
+  | {
+      storage: SessionStorage;
+      cookie: SessionIdStorageStrategy['cookie'];
+    }
+);
 
 export interface AuthLoaderSuccessData {
   accessToken: string;


### PR DESCRIPTION
This PR addresses issue #63 where users deploying to serverless environments (like AWS Lambda) experience errors in the callback route during cold starts. The error occurs because the session storage configuration happens in the root loader, but during cold starts the callback route might be hit first, resulting in:

```
Error: SessionStorage was never configured. Did you forget to call configureSessionStorage in your root loader?
```

## Changes

- Updated the `authLoader` function to accept the same `storage` and `cookie` configuration options that `authkitLoader` already supports
- Modified `HandleAuthOptions` type to support these new configuration options
- Changed the implementation to use `configureSessionStorage` directly in the callback route

## How It Works

When a cold start happens in a serverless environment, the callback route can now configure session storage itself through the same interface already available in `authkitLoader`. This allows developers to provide consistent session storage configuration to both routes, ensuring the application works correctly regardless of which route is hit first.

## Usage

For applications deployed to serverless environments, you can now use this pattern:

```typescript
// Create a shared configuration function
function getAuthStorage() {
  return {
    storage: createCookieSessionStorage({...}),
    cookie: { name: "my-session" }
  };
}

// In your root loader
export const loader = (args) => authkitLoader(args, {
  ...getAuthStorage(),
  // Other options...
});

// In your callback route
export const loader = authLoader({
  ...getAuthStorage(),
  // Other options...
});
```

This ensures consistent session configuration across routes and prevents cold start errors.

## README changes

This PR also adds a section describing sessoion storage configuration to the README, and notes the important case to configure in both laoders (when custom session storage is used).

Fixes #63.