### PR TITLE
fix: return null user when access token is expired in withAuth

### DIFF
--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -407,18 +407,13 @@ describe('auth', () => {
       const result = await withAuth(createMockRequest('wos-session=expired-session-data'));
 
       // Should warn about expired token
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Access token expired for user');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.'
+      );
 
-      // Result should still contain user info
+      // Result should return null user when token is expired
       expect(result).toEqual({
-        user: mockSession.user,
-        sessionId: mockClaims.sessionId,
-        organizationId: mockClaims.organizationId,
-        role: mockClaims.role,
-        permissions: mockClaims.permissions,
-        entitlements: mockClaims.entitlements,
-        impersonator: undefined,
-        accessToken: mockSession.accessToken,
+        user: null,
       });
 
       consoleWarnSpy.mockRestore();

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -408,7 +408,7 @@ describe('auth', () => {
 
       // Should warn about expired token
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.'
+        '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.',
       );
 
       // Result should return null user when token is expired

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -56,7 +56,12 @@ export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoU
   if (Date.now() >= exp * 1000) {
     // The access token is expired. This function does not handle token refresh.
     // Ensure that token refresh is implemented in the parent/root loader as documented.
-    console.warn('Access token expired for user');
+    console.warn(
+      '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.'
+    );
+    return {
+      user: null,
+    };
   }
 
   return {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,7 +57,7 @@ export async function withAuth(args: LoaderFunctionArgs): Promise<UserInfo | NoU
     // The access token is expired. This function does not handle token refresh.
     // Ensure that token refresh is implemented in the parent/root loader as documented.
     console.warn(
-      '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.'
+      '[AuthKit] Access token expired. Ensure authkitLoader is used in a parent/root route to handle automatic token refresh.',
     );
     return {
       user: null,


### PR DESCRIPTION
## Summary
- Changed `withAuth` to return `{ user: null }` when access token is expired
- Updated warning message to be more descriptive with `[AuthKit]` prefix
- This prevents developers from accidentally using expired tokens

## Problem
Users reported that `withAuth` returns expired access tokens with just a console warning, making it difficult to know the token is expired without manually decoding it. This leads to confusing errors downstream when the expired token is used with WorkOS APIs.

## Solution
When the access token is expired, `withAuth` now returns `{ user: null }` instead of returning the expired token data. This provides:
- **Consistent API**: Expired auth is treated the same as no auth
- **Safe by default**: No risk of using expired tokens
- **Simple mental model**: Either you have valid auth or you don't
- **Backward compatible**: Code checking `if (auth.user)` continues to work correctly

## Test plan
- [x] Updated test to verify new behavior
- [x] All existing tests pass
- [x] Manual testing confirms expired tokens return null user

## Related
- Same fix applied to authkit-react-router: https://github.com/workos/authkit-react-router/pull/32