### PR TITLE
fix: use fresh user data when refreshing sessions

### DIFF
--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -743,6 +743,20 @@ describe('session', () => {
         authenticateWithRefreshToken.mockResolvedValue({
           accessToken: 'new.valid.token',
           refreshToken: 'new.refresh.token',
+          user: {
+            object: 'user',
+            id: 'user-1',
+            email: 'test@example.com',
+            emailVerified: true,
+            profilePictureUrl: null,
+            firstName: 'Test',
+            lastName: 'User',
+            lastSignInAt: '2021-01-01T00:00:00Z',
+            createdAt: '2021-01-01T00:00:00Z',
+            updatedAt: '2021-01-01T00:00:00Z',
+            externalId: null,
+          },
+          impersonator: undefined,
         } as AuthenticationResponse);
 
         // Mock different JWT decoding results for expired vs new token
@@ -907,6 +921,20 @@ describe('session', () => {
       authenticateWithRefreshToken.mockResolvedValue({
         accessToken: 'new.valid.token',
         refreshToken: 'new.refresh.token',
+        user: {
+          object: 'user',
+          id: 'user-1',
+          email: 'test@example.com',
+          emailVerified: true,
+          profilePictureUrl: null,
+          firstName: 'Test',
+          lastName: 'User',
+          lastSignInAt: '2021-01-01T00:00:00Z',
+          createdAt: '2021-01-01T00:00:00Z',
+          updatedAt: '2021-01-01T00:00:00Z',
+          externalId: null,
+        },
+        impersonator: undefined,
       } as AuthenticationResponse);
 
       // Mock JWT decoding


### PR DESCRIPTION
## Summary

Fixes an issue where `refreshSession` and `updateSession` were preserving stale user and impersonator data from existing sessions instead of using the fresh data returned by the WorkOS `authenticateWithRefreshToken` API.

## Changes

- Updated `refreshSession` and `updateSession` to use current user/impersonator data from the API response
- Fixed test mocks to include the expected user data in the authentication response
- Ensures sessions stay up-to-date with any user attribute or impersonation status changes

## Test Plan

- [x] All existing tests pass
- [x] Updated test mocks to match real API behavior  
- [x] Verified lint checks pass

This change is consistent with the same fix applied to authkit-react-router.