### PR TITLE
fix: Preserve session on transient refresh failures

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,12 @@ export interface RefreshErrorOptions {
   error: unknown;
   request: Request;
   sessionData: SessionData;
+  /**
+   * Whether the refresh failed for a transient reason (network error, timeout,
+   * 429, or 5xx) rather than a terminal one. When `true` the existing session
+   * is preserved for a later retry instead of being destroyed.
+   */
+  isTransient: boolean;
 }
 
 export interface RefreshSuccessOptions {

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -899,6 +899,12 @@ describe('session', () => {
         ['a server error (503)', Object.assign(new Error('Service unavailable'), { status: 503 })],
         ['a request timeout (408)', Object.assign(new Error('Request timeout'), { status: 408 })],
         ['a network error', new TypeError('fetch failed')],
+        // The SDK re-wraps a raw network TypeError in a plain Error with the
+        // TypeError as its cause; the classifier must follow the cause chain.
+        [
+          'an SDK-wrapped network error',
+          new Error('Unexpected error: TypeError: fetch failed', { cause: new TypeError('fetch failed') }),
+        ],
       ])('should preserve the session cookie when refresh fails transiently: %s', async (_label, transientError) => {
         authenticateWithRefreshToken.mockRejectedValue(transientError);
         getAuthorizationUrlMock.mockResolvedValue('https://auth.workos.com/oauth/authorize?state=abc123');

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -894,6 +894,44 @@ describe('session', () => {
         }
       });
 
+      it.each([
+        ['a rate limit (429)', Object.assign(new Error('Too many requests'), { status: 429 })],
+        ['a server error (503)', Object.assign(new Error('Service unavailable'), { status: 503 })],
+        ['a request timeout (408)', Object.assign(new Error('Request timeout'), { status: 408 })],
+        ['a network error', new TypeError('fetch failed')],
+      ])('should preserve the session cookie when refresh fails transiently: %s', async (_label, transientError) => {
+        authenticateWithRefreshToken.mockRejectedValue(transientError);
+        getAuthorizationUrlMock.mockResolvedValue('https://auth.workos.com/oauth/authorize?state=abc123');
+
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+          fail('Expected redirect response to be thrown');
+        } catch (response: unknown) {
+          assertIsResponse(response);
+          expect(response.status).toBe(302);
+          // The sealed session must not be destroyed on a transient failure.
+          expect(destroySession).not.toHaveBeenCalled();
+          expect(response.headers.get('Set-Cookie')).toBeNull();
+        }
+      });
+
+      it('should destroy the session for a terminal refresh failure (invalid_grant)', async () => {
+        authenticateWithRefreshToken.mockRejectedValue(
+          Object.assign(new Error('invalid_grant'), { status: 400, error: 'invalid_grant' }),
+        );
+        getAuthorizationUrlMock.mockResolvedValue('https://auth.workos.com/oauth/authorize?state=abc123');
+
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+          fail('Expected redirect response to be thrown');
+        } catch (response: unknown) {
+          assertIsResponse(response);
+          expect(response.status).toBe(302);
+          expect(destroySession).toHaveBeenCalled();
+          expect(response.headers.get('Set-Cookie')).toBe('destroyed-session-cookie');
+        }
+      });
+
       it('calls onSessionRefreshError when provided and refresh fails', async () => {
         authenticateWithRefreshToken.mockRejectedValue(new Error('Refresh token invalid'));
         const onSessionRefreshError = jest.fn().mockReturnValue(redirect('/error'));

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -949,6 +949,30 @@ describe('session', () => {
         expect(onSessionRefreshError).toHaveBeenCalled();
       });
 
+      it('passes isTransient: true to onSessionRefreshError for a transient failure', async () => {
+        authenticateWithRefreshToken.mockRejectedValue(
+          Object.assign(new Error('Service unavailable'), { status: 503 }),
+        );
+        const onSessionRefreshError = jest.fn().mockReturnValue(redirect('/error'));
+
+        await authkitLoader(createLoaderArgs(createMockRequest()), {
+          onSessionRefreshError,
+        });
+
+        expect(onSessionRefreshError).toHaveBeenCalledWith(expect.objectContaining({ isTransient: true }));
+      });
+
+      it('passes isTransient: false to onSessionRefreshError for a terminal failure', async () => {
+        authenticateWithRefreshToken.mockRejectedValue(Object.assign(new Error('invalid_grant'), { status: 400 }));
+        const onSessionRefreshError = jest.fn().mockReturnValue(redirect('/error'));
+
+        await authkitLoader(createLoaderArgs(createMockRequest()), {
+          onSessionRefreshError,
+        });
+
+        expect(onSessionRefreshError).toHaveBeenCalledWith(expect.objectContaining({ isTransient: false }));
+      });
+
       it('allows redirect from onSessionRefreshError callback', async () => {
         authenticateWithRefreshToken.mockRejectedValue(new Error('Refresh token invalid'));
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -23,10 +23,49 @@ export type TypedResponse<T> = Response & {
 };
 
 export class SessionRefreshError extends Error {
+  /**
+   * Whether the refresh failed for a transient reason (network error, timeout,
+   * 429, or 5xx) rather than a terminal one (the refresh token is dead). When
+   * `true`, the existing session is still valid and should be preserved and
+   * retried rather than destroyed.
+   */
+  readonly isTransient: boolean;
+
   constructor(cause: unknown) {
     super('Session refresh error', { cause });
     this.name = 'SessionRefreshError';
+    this.isTransient = isTransientRefreshError(cause);
   }
+}
+
+// HTTP statuses the WorkOS SDK treats as idempotent/retryable and retries
+// internally. If one of these still surfaces, the failure is transient rather
+// than a dead refresh token: request timeouts (normalized to 408), rate limits
+// (429), and 5xx.
+const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+/**
+ * Determines whether a failed refresh is transient (the session should be
+ * preserved and retried) rather than terminal (the refresh token is dead and
+ * the user must re-authenticate).
+ *
+ * Mirrors the WorkOS SDK's own retry classification: a network-level failure
+ * surfaces as a `TypeError` from the fetch client once its internal retries are
+ * exhausted, and transient HTTP responses carry a numeric `status` in the
+ * retryable set. Anything else (a terminal `invalid_grant` at 400, a 401, or an
+ * unrecognized error) is treated as terminal.
+ */
+export function isTransientRefreshError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const { status } = error;
+    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
+  }
+
+  return false;
 }
 
 /**
@@ -396,6 +435,16 @@ export async function authkitLoader<Data = unknown>(
       }
 
       const returnPathname = getReturnPathname(request.url);
+
+      // Only destroy the session for a terminal failure. A transient failure
+      // (network error, timeout, 429, or 5xx that survived the SDK's internal
+      // retries) leaves the refresh token valid, so keep the sealed cookie and
+      // let a later request refresh successfully rather than forcing the user
+      // to re-authenticate.
+      if (error.isTransient) {
+        throw redirect(await getAuthorizationUrl({ returnPathname }));
+      }
+
       throw redirect(await getAuthorizationUrl({ returnPathname }), {
         headers: {
           'Set-Cookie': await destroySession(cookieSession),

--- a/src/session.ts
+++ b/src/session.ts
@@ -44,28 +44,47 @@ export class SessionRefreshError extends Error {
 // (429), and 5xx.
 const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
+// A network-level fetch failure surfaces as a TypeError ("fetch failed" /
+// "Failed to fetch"). Match its message so an unrelated programming TypeError
+// isn't misclassified as a transient (and therefore session-preserving) error.
+const NETWORK_ERROR_MESSAGE = /fetch failed|failed to fetch|network|load failed|terminated/i;
+
+// A raw network TypeError is not an HttpClientError, so the WorkOS SDK re-wraps
+// it in a plain Error whose `cause` is the original TypeError. Follow the cause
+// chain to recognize it.
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return NETWORK_ERROR_MESSAGE.test(error.message);
+  }
+
+  if (error instanceof Error && error.cause != null && error.cause !== error) {
+    return isNetworkError(error.cause);
+  }
+
+  return false;
+}
+
 /**
  * Determines whether a failed refresh is transient (the session should be
  * preserved and retried) rather than terminal (the refresh token is dead and
  * the user must re-authenticate).
  *
- * Mirrors the WorkOS SDK's own retry classification: a network-level failure
- * surfaces as a `TypeError` from the fetch client once its internal retries are
- * exhausted, and transient HTTP responses carry a numeric `status` in the
- * retryable set. Anything else (a terminal `invalid_grant` at 400, a 401, or an
- * unrecognized error) is treated as terminal.
+ * Mirrors the WorkOS SDK's own retry classification: transient HTTP responses
+ * (request timeout normalized to `408`, `429`, and `5xx`) surface as an
+ * exception carrying a retryable numeric `status`, and a network-level failure
+ * surfaces as a `TypeError` (wrapped by the SDK in an `Error` with the
+ * `TypeError` as its `cause`). Anything else (a terminal `invalid_grant` at
+ * 400, a 401, or an unrecognized error) is treated as terminal.
  */
 export function isTransientRefreshError(error: unknown): boolean {
-  if (error instanceof TypeError) {
-    return true;
-  }
-
   if (typeof error === 'object' && error !== null && 'status' in error) {
     const { status } = error;
-    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
+    if (typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status)) {
+      return true;
+    }
   }
 
-  return false;
+  return isNetworkError(error);
 }
 
 /**
@@ -421,6 +440,7 @@ export async function authkitLoader<Data = unknown>(
             error: error.cause,
             request,
             sessionData: cookieSession,
+            isTransient: error.isTransient,
           });
 
           if (result instanceof Response) {


### PR DESCRIPTION
## Summary

`authkitLoader` caught **any** `SessionRefreshError` and destroyed the sealed session + redirected to sign-in. That includes *transient* failures (network error, request timeout, `429`, `5xx`) that survive the SDK's internal retries — so a brief outage discards a still-valid refresh token and forces re-authentication (the BaseTen lockout pattern).

This classifies the wrapped refresh error and only destroys the session for a **terminal** failure. On a transient failure the sealed cookie is kept, so a later request refreshes successfully once the condition clears.

```ts
// session.ts — authkitLoader catch, on SessionRefreshError
if (error.isTransient) {
  // keep the cookie: redirect without destroySession()
  throw redirect(await getAuthorizationUrl({ returnPathname }));
}
// terminal (unchanged): destroy the session and redirect
throw redirect(await getAuthorizationUrl({ returnPathname }), {
  headers: { 'Set-Cookie': await destroySession(cookieSession) },
});
```

`SessionRefreshError` now carries an `isTransient` flag derived from the wrapped cause, using the SDK's own retry classification — a network failure surfaces as a `TypeError`; transient HTTP responses carry a retryable numeric `status`:

```ts
const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);

export function isTransientRefreshError(error: unknown): boolean {
  if (error instanceof TypeError) return true; // network / DNS / connection reset
  if (typeof error === 'object' && error !== null && 'status' in error) {
    const { status } = error;
    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
  }
  return false; // terminal: invalid_grant (400), 401, or unrecognized
}
```

`onSessionRefreshError` still runs for both cases, so consumers can override behavior. Terminal `invalid_grant`/`401`/unrecognized errors still destroy the cookie and redirect.

## Test plan
- `npm test` (95 tests pass), `npm run lint`, `prettier --check`, and `tsc --noEmit` all green.
- New `session.spec.ts` coverage: parametrized transient cases (`429`, `503`, `408`, network `TypeError`) assert `destroySession` is **not** called and no `Set-Cookie` is emitted; a terminal `invalid_grant` (`400`) case asserts the session **is** destroyed.

Part of the AuthKit refresh-token DX work (server returns `429` for transient refresh lock timeouts in workos/workos#66577; typed transient/terminal `session.refresh()` in workos/workos-node#1663; matching fix for Next.js in workos/authkit-nextjs#461).


Link to Devin session: https://app.devin.ai/sessions/fc39103abf694f90b1c92dd714a81461
Requested by: @m0tzy