### PR TITLE
Add optional issuer config for access token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ When retrieving configuration values, AuthKit follows this priority order:
 |  `cookieMaxAge` |  `WORKOS_COOKIE_MAX_AGE` |  `34560000` (400 days) |  No |  Maximum age of cookie in seconds |  
 |  `apiHostname` |  `WORKOS_API_HOSTNAME` |  `api.workos.com` |  No |  WorkOS API hostname |  
 |  `apiPort` |  `WORKOS_API_PORT` |  - |  No |  Port to use for API calls | 
+|  `issuer` |  `WORKOS_ISSUER` |  - |  No |  Expected `iss` claim of access tokens. When not set, the issuer claim is not validated | 
 
 >[!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When retrieving configuration values, AuthKit follows this priority order:
 |  `cookieMaxAge` |  `WORKOS_COOKIE_MAX_AGE` |  `34560000` (400 days) |  No |  Maximum age of cookie in seconds |  
 |  `apiHostname` |  `WORKOS_API_HOSTNAME` |  `api.workos.com` |  No |  WorkOS API hostname |  
 |  `apiPort` |  `WORKOS_API_PORT` |  - |  No |  Port to use for API calls | 
-|  `issuer` |  `WORKOS_ISSUER` |  - |  No |  Expected `iss` claim of access tokens. When not set, the issuer claim is not validated | 
+|  `issuer` |  `WORKOS_ISSUER` |  - |  No |  Expected `iss` claim of access tokens (comma-separated to accept multiple issuers). When not set, the issuer claim is not validated | 
 
 >[!NOTE]
 >

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -109,6 +109,16 @@ describe('config', () => {
     expect(typeof getConfig('apiHttps')).toBe('boolean');
   });
 
+  it('parses a comma-separated WORKOS_ISSUER into a list', () => {
+    configure((key) => (key === 'WORKOS_ISSUER' ? 'https://a.example.com, https://b.example.com,' : undefined));
+    expect(getConfig('issuer')).toEqual(['https://a.example.com', 'https://b.example.com']);
+  });
+
+  it('keeps a single WORKOS_ISSUER as a string', () => {
+    configure((key) => (key === 'WORKOS_ISSUER' ? 'https://a.example.com' : undefined));
+    expect(getConfig('issuer')).toBe('https://a.example.com');
+  });
+
   it('throws an error if cookiePassword is too short', () => {
     expect(() => {
       configure({ cookiePassword: 'short' });

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,14 @@ export class Configuration {
         return (isNaN(num) ? undefined : num) as AuthKitConfig[K];
       }
 
+      if (key === 'issuer' && typeof envValue === 'string') {
+        const issuers = envValue
+          .split(',')
+          .map((issuer) => issuer.trim())
+          .filter(Boolean);
+        return (issuers.length <= 1 ? issuers[0] : issuers) as AuthKitConfig[K];
+      }
+
       return envValue as AuthKitConfig[K];
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -177,6 +177,13 @@ export interface AuthKitConfig {
   apiPort?: number;
 
   /**
+   * The expected `iss` claim of WorkOS access tokens
+   * Equivalent to the WORKOS_ISSUER environment variable
+   * When not set, the issuer claim is not validated
+   */
+  issuer?: string;
+
+  /**
    * The maximum age of the session cookie in seconds
    * Equivalent to the WORKOS_COOKIE_MAX_AGE environment variable
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -177,11 +177,11 @@ export interface AuthKitConfig {
   apiPort?: number;
 
   /**
-   * The expected `iss` claim of WorkOS access tokens
-   * Equivalent to the WORKOS_ISSUER environment variable
+   * The expected `iss` claim of WorkOS access tokens, or a list of accepted issuers
+   * Equivalent to the WORKOS_ISSUER environment variable (comma-separated for a list)
    * When not set, the issuer claim is not validated
    */
-  issuer?: string;
+  issuer?: string | string[];
 
   /**
    * The maximum age of the session cookie in seconds

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -439,6 +439,23 @@ describe('session', () => {
         }
       });
 
+      it('accepts a comma-separated list of issuers', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_ISSUER = 'https://auth.example.com,https://api.workos.com/user_management/client_123';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_ISSUER;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({
+            issuer: ['https://auth.example.com', 'https://api.workos.com/user_management/client_123'],
+          });
+        }
+      });
+
       it('should handle roles array with multiple roles', async () => {
         // Override the JWT decoding to return multiple roles
         (jose.decodeJwt as jest.Mock).mockReturnValueOnce({

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -413,6 +413,32 @@ describe('session', () => {
         });
       });
 
+      it('does not validate the access token issuer claim by default', async () => {
+        jwtVerify.mockClear();
+        await authkitLoader(createLoaderArgs(createMockRequest()));
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[0]).toBe('valid.jwt.token');
+          expect(call[2]).toBeUndefined();
+        }
+      });
+
+      it('validates the access token issuer claim when issuer is configured', async () => {
+        jwtVerify.mockClear();
+        process.env.WORKOS_ISSUER = 'https://auth.example.com';
+        try {
+          await authkitLoader(createLoaderArgs(createMockRequest()));
+        } finally {
+          delete process.env.WORKOS_ISSUER;
+        }
+
+        expect(jwtVerify).toHaveBeenCalled();
+        for (const call of jwtVerify.mock.calls) {
+          expect(call[2]).toEqual({ issuer: 'https://auth.example.com' });
+        }
+      });
+
       it('should handle roles array with multiple roles', async () => {
         // Override the JWT decoding to return multiple roles
         (jose.decodeJwt as jest.Mock).mockReturnValueOnce({

--- a/src/session.ts
+++ b/src/session.ts
@@ -655,8 +655,9 @@ export async function getSessionFromCookie(cookie: string, session?: SessionData
 
 async function verifyAccessToken(accessToken: string) {
   const JWKS = createRemoteJWKSet(new URL(getWorkOS().userManagement.getJwksUrl(getConfig('clientId'))));
+  const issuer = getConfig('issuer');
   try {
-    await jwtVerify(accessToken, JWKS);
+    await jwtVerify(accessToken, JWKS, issuer ? { issuer } : undefined);
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
## Summary

Adds an opt-in `iss` claim check to access token verification via a new `issuer` config key (`configure({ issuer })` or `WORKOS_ISSUER`, resolved by the existing generic `getConfig` env-var mapping). When set, it is passed to `jose.jwtVerify`; when unset, behavior is unchanged (no `iss` check).

```ts
const issuer = getConfig('issuer');
await jwtVerify(accessToken, JWKS, issuer ? { issuer } : undefined);
```

`issuer` is `string | string[]` so an app can accept tokens from more than one issuer (e.g. during an issuer migration); `jose`'s `issuer` option already accepts both. `WORKOS_ISSUER` is split on commas in `Configuration.getValue` (trimmed, empties dropped; a single value stays a string):

```ts
configure({ issuer: 'https://api.workos.com/user_management/client_123' });
configure({ issuer: ['https://api.workos.com', 'https://api.workos.com/user_management/client_123'] });
// WORKOS_ISSUER=https://api.workos.com,https://api.workos.com/user_management/client_123
```

Opt-in rather than defaulted because the API does not mint a single issuer shape — it varies by environment (`https://api.workos.com` for legacy environments, `https://api.workos.com/user_management/<clientId>` for environments created since mid-2025, custom auth domains, and flag-gated path variants). Mirrors workos/authkit-nextjs#476.

Link to Devin session: https://app.devin.ai/sessions/0ee38e859a9849658a7cdb2d215d89a6
Open in Devin Desktop: https://app.devin.ai/desktop/session/0ee38e859a9849658a7cdb2d215d89a6?variant=devin
Requested by: @m0tzy